### PR TITLE
Remove double-space in a currency item

### DIFF
--- a/js/game/utils.js
+++ b/js/game/utils.js
@@ -38,7 +38,7 @@ function getCoinsData() {
         ];
         case 1: return [
             { "name": " 𒀱", "color": "#ffffff", "value": 1e62, "class": "currency-shadow-rainbow" },
-            { "name": "  𒀱", "color": "#ffffff", "value": 1e47, "class": "currency-shadow" },
+            { "name": " 𒀱", "color": "#ffffff", "value": 1e47, "class": "currency-shadow" },
             { "name": " 𒇫", "color": "#66ccff", "value": 1e41, "class": "currency-shadow" },
             { "name": " 🜊", "color": "#00ff00", "value": 1e35, "class": "currency-bold" },
             { "name": "✹", "color": "#ffffcc", "value": 1e30 },


### PR DESCRIPTION
The second highest valued item in the "Extended" notation had two spaces before the unit instead of one. This was most likely a copy error or typo.