### PR TITLE
Truncate coins at 1000 of a single unit

### DIFF
--- a/js/game/utils.js
+++ b/js/game/utils.js
@@ -138,7 +138,7 @@ function formatCoins(coins, element, showFree = false) {
                     element.children[coinsUsed].className = "usedCoin"
                     coinsUsed++
                 }
-                if (coinsUsed >= data.settings.coinsDisplayed) break;
+                if (coinsUsed >= data.settings.coinsDisplayed || amount >= 1000) break;
             }
             break;
         case 3:


### PR DESCRIPTION
Once one has thousands or millions of pounds in the bank, there is no (practical) need to show how many shillings or pence they have; it is unnecessary given the pound amount is itself abbreviated.

I've fixed this unnecessary precision by truncating out (not displaying) lower-value coin types at 1,000 of a given coin type, as that is the default threshold when numbers are abbreviated. With the current content, this affects the classic and British coin notations due to them only having a very limited number of coin types.

|  | Classic | British |
| -------- | ------- | ------- |
| Before | ![image](https://github.com/user-attachments/assets/b61c98a2-82bf-4aab-af43-0520e3d05786) | ![image](https://github.com/user-attachments/assets/5a4f968a-12fb-4469-8be4-7cbbfe5d4f9a) |
| After | ![image](https://github.com/user-attachments/assets/c2a494fb-baa8-46d3-8e50-6a0c5528c336) | ![image](https://github.com/user-attachments/assets/44145238-8f7a-4ff7-8f16-ef460375e754) |


